### PR TITLE
Update devcontainer.json to install dependencies in a custom node_modules folder

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "yarn --cwd webapp/ install"
+	"postCreateCommand": "yarn --cwd webapp/ --modules-folder ../node_modules install"
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
This pull request includes a small change to the `.devcontainer/devcontainer.json` file. The change modifies the `postCreateCommand` to specify the `--modules-folder` option for the `yarn` command.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L25-R25): Changed the `postCreateCommand` to `yarn --cwd webapp/ --modules-folder ../node_modules install` to specify the location of the `node_modules` directory.